### PR TITLE
Use better DMG Compression

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -412,7 +412,7 @@
             <arg value="convert"/>
             <arg value="${dmg.path.tmp}"/>
             <arg value="-format"/>
-            <arg value="UDZO"/>
+            <arg value="UDBZ"/>
             <arg value="-o"/>
             <arg value="${dmg.path}"/>
         </exec>


### PR DESCRIPTION
Not sure if this is the best way to suggest this change... using UDBZ compression will save about 4 MB off the DMG size, but the DMG only works with OS X 10.4 or newer (not a problem here obviously).